### PR TITLE
[Fix] 게시글 상세 조회, 전체 게시글 조회 API 수정

### DIFF
--- a/src/main/java/com/devsong/server/post/controller/PostController.java
+++ b/src/main/java/com/devsong/server/post/controller/PostController.java
@@ -1,19 +1,7 @@
 package com.devsong.server.post.controller;
 
-import com.devsong.server.post.dto.CommentRequestDto;
-import com.devsong.server.post.dto.CommentResponseDto;
-import com.devsong.server.post.service.CommentService;
-import com.devsong.server.post.dto.PostCreateResponseDto;
-import com.devsong.server.post.dto.PostListResponseDto;
-import com.devsong.server.post.dto.PostResponseDto;
-import com.devsong.server.post.dto.PostCreateRequestDto;
-import com.devsong.server.post.service.PostService;
-import com.devsong.server.post.dto.PostApplyRequestDto;
-import com.devsong.server.post.dto.PostApplyResponseDto;
-import com.devsong.server.post.service.PostApplyService;
-import com.devsong.server.post.dto.PostLikeRequestDto;
-import com.devsong.server.post.dto.PostLikeResponseDto;
-import com.devsong.server.post.service.PostLikeService;
+import com.devsong.server.post.dto.*;
+import com.devsong.server.post.service.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -41,8 +29,8 @@ public class PostController {
 
     //게시글 상세정보 조회
     @GetMapping("/{id}")
-    public ResponseEntity<PostResponseDto> getPost(@PathVariable Long id) {
-        PostResponseDto responseDto = postService.findPost(id);
+    public ResponseEntity<PostDetailResponseDto> getPost(@PathVariable Long id) {
+        PostDetailResponseDto responseDto = postService.findPost(id);
         return ResponseEntity.ok(responseDto);
     }
 

--- a/src/main/java/com/devsong/server/post/dto/CommentResponseDto.java
+++ b/src/main/java/com/devsong/server/post/dto/CommentResponseDto.java
@@ -1,5 +1,7 @@
 package com.devsong.server.post.dto;
 
+import com.devsong.server.post.entity.Comment;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,5 +18,16 @@ public class CommentResponseDto {
     private Long userId;
     private Long postId;
     private String content;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createdAt;
+
+    public static CommentResponseDto fromEntity(Comment comment) {
+        return new CommentResponseDto(
+                comment.getId(),
+                comment.getUser().getId(),
+                comment.getPost().getId(),
+                comment.getContent(),
+                comment.getCreatedAt()
+        );
+    }
 }

--- a/src/main/java/com/devsong/server/post/dto/CommentResponseDto.java
+++ b/src/main/java/com/devsong/server/post/dto/CommentResponseDto.java
@@ -21,13 +21,4 @@ public class CommentResponseDto {
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createdAt;
 
-    public static CommentResponseDto fromEntity(Comment comment) {
-        return new CommentResponseDto(
-                comment.getId(),
-                comment.getUser().getId(),
-                comment.getPost().getId(),
-                comment.getContent(),
-                comment.getCreatedAt()
-        );
-    }
 }

--- a/src/main/java/com/devsong/server/post/dto/PostCreateRequestDto.java
+++ b/src/main/java/com/devsong/server/post/dto/PostCreateRequestDto.java
@@ -9,24 +9,12 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-    @NoArgsConstructor
-    @Builder
-    @AllArgsConstructor
-    public class PostCreateRequestDto {
-        private String title;
-        private String content;
-        private Category category;
-        private boolean closed;
-        private Long userId;
-
-
-        public Post toEntity(User user) {
-            return Post.builder()
-                    .title(title)
-                    .content(content)
-                    .category(category)
-                    .closed(closed)
-                    .user(user)
-                    .build();
-        }
-    }
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class PostCreateRequestDto {
+    private String title;
+    private String content;
+    private Category category;
+    private Long userId;
+}

--- a/src/main/java/com/devsong/server/post/dto/PostDetailResponseDto.java
+++ b/src/main/java/com/devsong/server/post/dto/PostDetailResponseDto.java
@@ -1,29 +1,26 @@
 package com.devsong.server.post.dto;
 
-import com.devsong.server.post.entity.Post;
-import com.devsong.server.post.dto.CommentResponseDto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Builder
 @Getter
 @AllArgsConstructor
-public class PostResponseDto {
+public class PostDetailResponseDto {
     private final Long id;
     private final String title;
     private final String username;
     private final String content;
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime createdAt;
-    private final boolean isClosed;
-    private final int like;
-    private final int comment;
-    private final List<CommentResponseDto> comments;
+    private final boolean closed; //마감여부
+    private final Long like; //좋아요 수
+    private final Long comment; //댓글 수
+    private final List<CommentResponseDto> comments; //댓글 리스트
 
 }
 

--- a/src/main/java/com/devsong/server/post/dto/PostListResponseDto.java
+++ b/src/main/java/com/devsong/server/post/dto/PostListResponseDto.java
@@ -17,9 +17,9 @@ public class PostListResponseDto {
     private final String content;
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime createdAt;
-    private final boolean isClosed;
-    private final int like;
-    private final int comment;
+    private final boolean closed;
+    private final Long like;
+    private final Long comment;
 
 }
 

--- a/src/main/java/com/devsong/server/post/dto/PostListResponseDto.java
+++ b/src/main/java/com/devsong/server/post/dto/PostListResponseDto.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 public class PostListResponseDto {
     private final Long id;
     private final String title;
-    private final String author;
+    private final String username;
     private final String content;
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime createdAt;
@@ -26,7 +26,7 @@ public class PostListResponseDto {
                 .id(post.getId())
                 .title(post.getTitle())
                 .content(post.getContent())
-                .author(post.getUser().getUsername())
+                .username(post.getUser().getUsername())
                 .createdAt(post.getCreatedAt())
                 .isClosed(post.isClosed())
                 .like(post.getLike())

--- a/src/main/java/com/devsong/server/post/dto/PostListResponseDto.java
+++ b/src/main/java/com/devsong/server/post/dto/PostListResponseDto.java
@@ -14,17 +14,23 @@ public class PostListResponseDto {
     private final Long id;
     private final String title;
     private final String author;
+    private final String content;
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime createdAt;
     private final boolean isClosed;
+    private final int like;
+    private final int comment;
 
     public static PostListResponseDto from(Post post) {
         return PostListResponseDto.builder()
                 .id(post.getId())
                 .title(post.getTitle())
+                .content(post.getContent())
                 .author(post.getUser().getUsername())
                 .createdAt(post.getCreatedAt())
                 .isClosed(post.isClosed())
+                .like(post.getLike())
+                .comment(post.getComment())
                 .build();
     }
 }

--- a/src/main/java/com/devsong/server/post/dto/PostListResponseDto.java
+++ b/src/main/java/com/devsong/server/post/dto/PostListResponseDto.java
@@ -21,18 +21,6 @@ public class PostListResponseDto {
     private final int like;
     private final int comment;
 
-    public static PostListResponseDto from(Post post) {
-        return PostListResponseDto.builder()
-                .id(post.getId())
-                .title(post.getTitle())
-                .content(post.getContent())
-                .username(post.getUser().getUsername())
-                .createdAt(post.getCreatedAt())
-                .isClosed(post.isClosed())
-                .like(post.getLike())
-                .comment(post.getComment())
-                .build();
-    }
 }
 
 

--- a/src/main/java/com/devsong/server/post/dto/PostResponseDto.java
+++ b/src/main/java/com/devsong/server/post/dto/PostResponseDto.java
@@ -25,22 +25,5 @@ public class PostResponseDto {
     private final int comment;
     private final List<CommentResponseDto> comments;
 
-    public static PostResponseDto from(Post post) {
-        return PostResponseDto.builder()
-                .id(post.getId())
-                .title(post.getTitle())
-                .content(post.getContent())
-                .username(post.getUser().getUsername())
-                .createdAt(post.getCreatedAt())
-                .isClosed(post.isClosed())
-                .like(post.getLike())
-                .comment(post.getComment())
-                .comments(
-                        post.getPostCommentList().stream()
-                                .map(comment -> CommentResponseDto.fromEntity(comment))
-                                .collect(Collectors.toList())
-                )
-                .build();
-    }
 }
 

--- a/src/main/java/com/devsong/server/post/dto/PostResponseDto.java
+++ b/src/main/java/com/devsong/server/post/dto/PostResponseDto.java
@@ -1,11 +1,13 @@
 package com.devsong.server.post.dto;
 
 import com.devsong.server.post.entity.Post;
+import com.devsong.server.post.dto.CommentResponseDto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import java.time.LocalDateTime;
+import java.util.stream.Collectors;
 
 @Builder
 @Getter
@@ -19,7 +21,7 @@ public class PostResponseDto {
     private final LocalDateTime createdAt;
     private final boolean isClosed;
     private final int like;
-    private final int comment;
+    private final List<CommentResponseDto> comments;
 
     public static PostResponseDto from(Post post) {
         return PostResponseDto.builder()
@@ -30,7 +32,11 @@ public class PostResponseDto {
                 .createdAt(post.getCreatedAt())
                 .isClosed(post.isClosed())
                 .like(post.getLike())
-                .comment(post.getComment())
+                .comments(
+                        post.getPostCommentList().stream()
+                                .map(comment -> CommentResponseDto.fromEntity(comment))
+                                .collect(Collectors.toList())
+                )
                 .build();
     }
 }

--- a/src/main/java/com/devsong/server/post/dto/PostResponseDto.java
+++ b/src/main/java/com/devsong/server/post/dto/PostResponseDto.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.stream.Collectors;
 
 @Builder
@@ -15,12 +16,13 @@ import java.util.stream.Collectors;
 public class PostResponseDto {
     private final Long id;
     private final String title;
-    private final String author;
+    private final String username;
     private final String content;
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime createdAt;
     private final boolean isClosed;
     private final int like;
+    private final int comment;
     private final List<CommentResponseDto> comments;
 
     public static PostResponseDto from(Post post) {
@@ -28,10 +30,11 @@ public class PostResponseDto {
                 .id(post.getId())
                 .title(post.getTitle())
                 .content(post.getContent())
-                .author(post.getUser().getUsername())
+                .username(post.getUser().getUsername())
                 .createdAt(post.getCreatedAt())
                 .isClosed(post.isClosed())
                 .like(post.getLike())
+                .comment(post.getComment())
                 .comments(
                         post.getPostCommentList().stream()
                                 .map(comment -> CommentResponseDto.fromEntity(comment))

--- a/src/main/java/com/devsong/server/post/dto/PostResponseDto.java
+++ b/src/main/java/com/devsong/server/post/dto/PostResponseDto.java
@@ -18,6 +18,8 @@ public class PostResponseDto {
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime createdAt;
     private final boolean isClosed;
+    private final int like;
+    private final int comment;
 
     public static PostResponseDto from(Post post) {
         return PostResponseDto.builder()
@@ -27,6 +29,8 @@ public class PostResponseDto {
                 .author(post.getUser().getUsername())
                 .createdAt(post.getCreatedAt())
                 .isClosed(post.isClosed())
+                .like(post.getLike())
+                .comment(post.getComment())
                 .build();
     }
 }

--- a/src/main/java/com/devsong/server/post/entity/Post.java
+++ b/src/main/java/com/devsong/server/post/entity/Post.java
@@ -34,18 +34,31 @@ public class Post {
 
     private LocalDateTime createdAt; //작성시각
 
+    //좋아요
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<PostLike> like = new ArrayList<>();
+    private List<PostLike> postLikeList = new ArrayList<>();
 
+    //댓글
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<PostLike> comment = new ArrayList<>();
+    private List<Comment> postCommentList = new ArrayList<>();
 
+    //지원자
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PostApply> postApplyList = new ArrayList<>();
+
+    //좋아요 수
     public int getLike() {
-        return like.size();
+        return postLikeList.size();
     }
 
+    //댓글 수
     public int getComment() {
-        return comment.size();
+        return postCommentList.size();
+    }
+
+    //지원자 수
+    public int getApply() {
+        return postApplyList.size();
     }
 
     @PrePersist

--- a/src/main/java/com/devsong/server/post/entity/Post.java
+++ b/src/main/java/com/devsong/server/post/entity/Post.java
@@ -34,33 +34,6 @@ public class Post {
 
     private LocalDateTime createdAt; //작성시각
 
-    //좋아요
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<PostLike> postLikeList = new ArrayList<>();
-
-    //댓글
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Comment> postCommentList = new ArrayList<>();
-
-    //지원자
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<PostApply> postApplyList = new ArrayList<>();
-
-    //좋아요 수
-    public int getLike() {
-        return postLikeList.size();
-    }
-
-    //댓글 수
-    public int getComment() {
-        return postCommentList.size();
-    }
-
-    //지원자 수
-    public int getApply() {
-        return postApplyList.size();
-    }
-
     @PrePersist
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();

--- a/src/main/java/com/devsong/server/post/entity/Post.java
+++ b/src/main/java/com/devsong/server/post/entity/Post.java
@@ -5,6 +5,8 @@ import lombok.*;
 
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Builder
 @Entity
@@ -31,6 +33,20 @@ public class Post {
     private boolean closed; //마감여부
 
     private LocalDateTime createdAt; //작성시각
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PostLike> like = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PostLike> comment = new ArrayList<>();
+
+    public int getLike() {
+        return like.size();
+    }
+
+    public int getComment() {
+        return comment.size();
+    }
 
     @PrePersist
     protected void onCreate() {

--- a/src/main/java/com/devsong/server/post/repository/CommentRepository.java
+++ b/src/main/java/com/devsong/server/post/repository/CommentRepository.java
@@ -1,11 +1,16 @@
 package com.devsong.server.post.repository;
 
+import com.devsong.server.post.dto.CommentResponseDto;
 import com.devsong.server.post.entity.Comment;
+import com.devsong.server.post.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    Long countByPostId(Long postId);
+    List<Comment> findByPostId(Long postId);
 }
-

--- a/src/main/java/com/devsong/server/post/repository/PostLikeRepository.java
+++ b/src/main/java/com/devsong/server/post/repository/PostLikeRepository.java
@@ -1,5 +1,6 @@
 package com.devsong.server.post.repository;
 
+import com.devsong.server.post.entity.Post;
 import com.devsong.server.post.entity.PostLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -8,4 +9,5 @@ import org.springframework.stereotype.Repository;
 public interface PostLikeRepository extends JpaRepository<PostLike, Long>  {
     boolean existsByUserIdAndPostId(Long userId, Long postId);
     void deleteByUserIdAndPostId(Long userId, Long postId);
+    Long countByPostId(Long postId);
 }

--- a/src/main/java/com/devsong/server/post/service/PostService.java
+++ b/src/main/java/com/devsong/server/post/service/PostService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -43,7 +44,26 @@ public class PostService {
     public PostResponseDto findPost(Long id) {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));
-        return PostResponseDto.from(post);
+        return new PostResponseDto(
+                post.getId(),
+                post.getTitle(),
+                post.getUser().getUsername(),
+                post.getContent(),
+                post.getCreatedAt(),
+                post.isClosed(),
+                post.getLike(),
+                post.getComment(),
+                post.getPostCommentList().stream()
+                        .map(comment -> new CommentResponseDto(
+                                comment.getId(),
+                                comment.getUser().getId(),
+                                comment.getPost().getId(),
+                                comment.getContent(),
+                                comment.getCreatedAt()
+                        ))
+                        .toList()
+                );
+
     }
 
 
@@ -51,7 +71,16 @@ public class PostService {
     @Transactional(readOnly = true)
     public List<PostListResponseDto> findAll() {
         return postRepository.findAllByOrderByIdDesc().stream()
-                .map(PostListResponseDto::from)
+                .map(post -> new PostListResponseDto(
+                        post.getId(),
+                        post.getTitle(),
+                        post.getContent(),
+                        post.getUser().getUsername(),
+                        post.getCreatedAt(),
+                        post.isClosed(),
+                        post.getLike(),
+                        post.getComment()
+                ))
                 .toList();
     }
 }

--- a/src/main/java/com/devsong/server/post/service/PostService.java
+++ b/src/main/java/com/devsong/server/post/service/PostService.java
@@ -2,22 +2,22 @@ package com.devsong.server.post.service;
 
 import com.devsong.server.post.dto.*;
 import com.devsong.server.post.entity.Post;
-import com.devsong.server.post.repository.PostRepository;
 import com.devsong.server.user.entity.User;
+import com.devsong.server.post.repository.*;
 import com.devsong.server.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class PostService {
     private final PostRepository postRepository;
     private final UserRepository userRepository;
-
+    private final PostLikeRepository postLikeRepository;
+    private final CommentRepository commentRepository;
 
     //게시글 등록
     @Transactional
@@ -41,29 +41,36 @@ public class PostService {
 
     //게시글 상세정보 조회 (없을 시 코멘트 출력)
     @Transactional(readOnly = true)
-    public PostResponseDto findPost(Long id) {
+    public PostDetailResponseDto findPost(Long id) {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));
-        return new PostResponseDto(
-                post.getId(),
-                post.getTitle(),
-                post.getUser().getUsername(),
-                post.getContent(),
-                post.getCreatedAt(),
-                post.isClosed(),
-                post.getLike(),
-                post.getComment(),
-                post.getPostCommentList().stream()
-                        .map(comment -> new CommentResponseDto(
-                                comment.getId(),
-                                comment.getUser().getId(),
-                                comment.getPost().getId(),
-                                comment.getContent(),
-                                comment.getCreatedAt()
-                        ))
-                        .toList()
-                );
 
+        //Entity -> ResponseDto 변환
+        return PostDetailResponseDto.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .username(post.getUser().getUsername())
+                .content(post.getContent())
+                .createdAt(post.getCreatedAt())
+                .closed(post.isClosed())
+                .like(
+                        postLikeRepository.countByPostId(post.getId())
+                )
+                .comment(
+                        commentRepository.countByPostId(post.getId())
+                )
+                .comments(
+                        commentRepository.findByPostId(post.getId()).stream()
+                                .map(comment -> CommentResponseDto.builder()
+                                        .commentId(comment.getId())
+                                        .userId(comment.getUser().getId())
+                                        .postId(comment.getPost().getId())
+                                        .content(comment.getContent())
+                                        .createdAt(comment.getCreatedAt())
+                                        .build()
+                                ).toList()
+                )
+                .build();
     }
 
 
@@ -71,16 +78,21 @@ public class PostService {
     @Transactional(readOnly = true)
     public List<PostListResponseDto> findAll() {
         return postRepository.findAllByOrderByIdDesc().stream()
-                .map(post -> new PostListResponseDto(
-                        post.getId(),
-                        post.getTitle(),
-                        post.getContent(),
-                        post.getUser().getUsername(),
-                        post.getCreatedAt(),
-                        post.isClosed(),
-                        post.getLike(),
-                        post.getComment()
-                ))
+                .map(post -> PostListResponseDto.builder()
+                                .id(post.getId())
+                                .title(post.getTitle())
+                                .username(post.getUser().getUsername())
+                                .content(post.getContent())
+                                .createdAt(post.getCreatedAt())
+                                .closed(post.isClosed())
+                                .like(
+                                        postLikeRepository.countByPostId(post.getId())
+                                )
+                                .comment(
+                                        commentRepository.countByPostId(post.getId())
+                                )
+                                .build()
+                        )
                 .toList();
     }
 }

--- a/src/main/java/com/devsong/server/post/service/PostService.java
+++ b/src/main/java/com/devsong/server/post/service/PostService.java
@@ -1,10 +1,7 @@
 package com.devsong.server.post.service;
 
-import com.devsong.server.post.dto.PostCreateRequestDto;
-import com.devsong.server.post.dto.PostCreateResponseDto;
-import com.devsong.server.post.dto.PostListResponseDto;
+import com.devsong.server.post.dto.*;
 import com.devsong.server.post.entity.Post;
-import com.devsong.server.post.dto.PostResponseDto;
 import com.devsong.server.post.repository.PostRepository;
 import com.devsong.server.user.entity.User;
 import com.devsong.server.user.repository.UserRepository;
@@ -24,9 +21,18 @@ public class PostService {
     //게시글 등록
     @Transactional
     public PostCreateResponseDto create(PostCreateRequestDto requestDto) {
-        User user = userRepository.findById(requestDto.getUserId()).get();
+        User user = userRepository.findById(requestDto.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("유저 정보를 찾을 수 없습니다."));
 
-        Post post = requestDto.toEntity(user);
+        //RequestDto -> Entity 변환
+        Post post = Post.builder()
+                .title(requestDto.getTitle())
+                .content(requestDto.getContent())
+                .category(requestDto.getCategory())
+                .closed(false) //마감여부 : dafualt 값을 false로
+                .user(user)
+                .build();
+
         postRepository.save(post);
         return new PostCreateResponseDto(post.getId());
     }


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
closed #6 
<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->
`    //좋아요
    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
    private List<PostLike> postLikeList = new ArrayList<>();

    //댓글
    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
    private List<Comment> postCommentList = new ArrayList<>();

    //지원자
    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
    private List<PostApply> postApplyList = new ArrayList<>();

    //좋아요 수
    public int getLike() {
        return postLikeList.size();
    }

    //댓글 수
    public int getComment() {
        return postCommentList.size();
    }

    //지원자 수
    public int getApply() {
        return postApplyList.size();
    }`
- Post 엔티티에 PostLike, Comment, PostApply 필드 추가 및 좋아요, 댓글, 지원자 수를 나타내는 메소드 추가
-  PostResponseDto에 누락된 like, comment 필드 추가
- PostListResponseDto에 누락된 category, content, like, comment 필드 추가
- PostResponseDto, PostListResponseDto에서 author -> username으로 필드 이름 통일
- CommentResponseDto에서 댓글 상세정보 반환하도록 수정 >>  To Reviewers 봐주세요

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
Post에서
`
    //좋아요 수
    public int getLike() {
        return postLikeList.size();
    }

    //댓글 수
    public int getComment() {
        return postCommentList.size();
    }

    //지원자 수
    public int getApply() {
        return postApplyList.size();
    }`
PostResponseDto에서
`                .comments(
                        post.getPostCommentList().stream()
                                .map(comment -> CommentResponseDto.fromEntity(comment))
                                .collect(Collectors.toList())
                )`
각각 service 단으로 옮길 수 있으면 그게 나을까요?

<img width="513" height="618" alt="image" src="https://github.com/user-attachments/assets/daf0f1a8-9b51-4ee5-91d3-72da203ac52d" />

게시물 상세 조회로 들어갔을 때 이렇게 뜨게 하고 싶었는데 댓글은 상세 조회 페이지가 따로 없어서 제가 CommentResponseDto에 댓글 정보들 반환하게 수정 요청을 드렸었는데 CommentResponseDto에 넣어도 괜찮을까요?
그리고 댓글에서 userId랑 postId 대신 각각 username, title 반환하게 바꾸고 싶은데 이건 백에서 수정할 필요가 없는 부분인가요?


<img width="779" height="129" alt="image" src="https://github.com/user-attachments/assets/ef103b9f-62f5-47fa-8b4a-9e5e0bdae85b" />

이부분 좋아요 수랑 댓글 내역은 별도의 테이블이 있어서 post 테이블에서 같이 조회가 불가능한 것 같은데 괜찮나요?

<br><br>
## 🔗 Reference
<!— 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) —>
- https://medium.com/@ksarang0104/spring-boot-%EB%8C%93%EA%B8%80-%EC%BB%A8%ED%8A%B8%EB%A1%A4%EB%9F%AC-%EC%84%9C%EB%B9%84%EC%8A%A4-%EB%A7%8C%EB%93%A4%EA%B8%B0-47fa360423b8