### PR TITLE
[Fix] 전체 게시물 조회 API response 수정

### DIFF
--- a/src/main/java/com/devsong/server/post/controller/PostController.java
+++ b/src/main/java/com/devsong/server/post/controller/PostController.java
@@ -48,7 +48,7 @@ public class PostController {
 
 
     //전체 게시글 목록 조회
-    @GetMapping("/list")
+    @GetMapping
     public List<PostListResponseDto> findAll() {
         return postService.findAll();
     }

--- a/src/main/java/com/devsong/server/post/dto/PostListResponseDto.java
+++ b/src/main/java/com/devsong/server/post/dto/PostListResponseDto.java
@@ -14,7 +14,7 @@ public class PostListResponseDto {
     private final Long id;
     private final String title;
     private final String username;
-    private final String content;
+    private final String previewContent;
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime createdAt;
     private final boolean isClosed;

--- a/src/main/java/com/devsong/server/post/dto/PostListResponseDto.java
+++ b/src/main/java/com/devsong/server/post/dto/PostListResponseDto.java
@@ -14,7 +14,7 @@ public class PostListResponseDto {
     private final Long id;
     private final String title;
     private final String username;
-    private final String previewContent;
+    private final String preview;
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime createdAt;
     private final boolean closed;

--- a/src/main/java/com/devsong/server/post/service/PostService.java
+++ b/src/main/java/com/devsong/server/post/service/PostService.java
@@ -82,7 +82,7 @@ public class PostService {
                                 .id(post.getId())
                                 .title(post.getTitle())
                                 .username(post.getUser().getUsername())
-                                .content(post.getContent())
+                                .preview(preview(post.getContent(), 80))
                                 .createdAt(post.getCreatedAt())
                                 .closed(post.isClosed())
                                 .like(
@@ -94,5 +94,9 @@ public class PostService {
                                 .build()
                         )
                 .toList();
+    }
+    private String preview(String content, int limit) {
+        if (content == null) return "";
+        return content.length() > limit ? content.substring(0, limit) + "..." : content;
     }
 }

--- a/src/main/java/com/devsong/server/post/service/PostService.java
+++ b/src/main/java/com/devsong/server/post/service/PostService.java
@@ -76,6 +76,7 @@ public class PostService {
                         post.getTitle(),
                         post.getContent(),
                         post.getUser().getUsername(),
+                        preview(post.getContent(), 80),
                         post.getCreatedAt(),
                         post.isClosed(),
                         post.getLike(),


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
closed #9 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->
- 전체 게시물 조회에서 본문 내용이 80자까지만 보이게 수정
- 전체 게시물 조회의 API 엔드포인트를 post로 수정

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
<img width="1208" height="274" alt="image" src="https://github.com/user-attachments/assets/6e31e0eb-0350-4bb1-a462-3acc5004fd96" />
<img width="499" height="283" alt="image" src="https://github.com/user-attachments/assets/0a131bd3-6730-40fb-b37f-52da5629a5d2" />
본문 내용이 80자 이하일 시 그대로 표시, 80자 초과일 시 ... 처리됩니다

<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!— 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) —>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 게시물 목록에 전체 본문 대신 잘린 미리보기(preview)를 표시하고, 길면 말줄임표(...)로 표시하여 빠르게 훑어볼 수 있습니다.
  * 게시물 목록 항목에 댓글 수가 함께 표시되어 참여도를 한눈에 확인할 수 있습니다.
  * 게시물 조회 엔드포인트가 단순화되어 GET /post로 전체 목록을 가져올 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->