### PR TITLE
[Fix] 이메일 중복확인 api 요청 토큰 없이 가능하도록 수정

### DIFF
--- a/src/main/java/com/devsong/server/jwt/SecurityConfig.java
+++ b/src/main/java/com/devsong/server/jwt/SecurityConfig.java
@@ -19,7 +19,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
                         //회원가입, 로그인 api 요청은 토큰 없이 가능하도록 허용
-                        .requestMatchers("/user/signup", "/user/login").permitAll()
+                        .requestMatchers("/user/signup", "/user/login", "/user/check-email").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/devsong/server/user/dto/EmailResponseDto.java
+++ b/src/main/java/com/devsong/server/user/dto/EmailResponseDto.java
@@ -6,5 +6,5 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class EmailResponseDto {
-    private boolean uniqueness;
+    private boolean available;
 }


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
closed #28 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->
이메일 중복확인 api 요청 토큰 없이 가능하도록 수정
+ api 응답 uniqueness -> available 수정

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
<img width="981" height="360" alt="image" src="https://github.com/user-attachments/assets/23d286ae-68ea-4698-beb6-959c07503cb8" />


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!— 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) —>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 이메일 중복 확인 API(/user/check-email)를 인증 없이 사용할 수 있습니다. 회원가입 전에 이메일 사용 가능 여부를 빠르게 확인하세요.
- 리팩터링
  - 이메일 중복 확인 응답 필드가 uniqueness에서 available로 변경되었습니다. 클라이언트는 응답 JSON의 키를 available로, 접근자도 isAvailable 사용으로 업데이트해야 합니다. 기존 키를 참조하는 경우 표시 오류가 발생할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->