### PR TITLE
[Refactor] 카테고리별 조회 API를 PathVariable에서 RequestParam 방식으로 수정

### DIFF
--- a/src/main/java/com/devsong/server/post/controller/PostController.java
+++ b/src/main/java/com/devsong/server/post/controller/PostController.java
@@ -43,8 +43,8 @@ public class PostController {
     }
 
     //카테고리별 조회
-    @GetMapping("/category/{category}")
-    public List<PostListResponseDto> findByCategory(@PathVariable Category category) {
+    @GetMapping("/category")
+    public List<PostListResponseDto> findByCategory(@RequestParam String category) {
         return postService.findByCategory(category);
     }
 

--- a/src/main/java/com/devsong/server/post/controller/PostController.java
+++ b/src/main/java/com/devsong/server/post/controller/PostController.java
@@ -38,14 +38,11 @@ public class PostController {
 
     //전체 게시글 목록 조회
     @GetMapping
-    public List<PostListResponseDto> findAll() {
-        return postService.findAll();
-    }
-
-    //카테고리별 조회
-    @GetMapping("/category")
-    public List<PostListResponseDto> findByCategory(@RequestParam String category) {
-        return postService.findByCategory(category);
+    public List<PostListResponseDto> findAll(@RequestParam(required = false) String category) {
+        if (category == null) {
+            return postService.findAll(); //전체조회
+        }
+        return postService.findByCategory(category); //카테고리별 조회
     }
 
 

--- a/src/main/java/com/devsong/server/post/service/PostService.java
+++ b/src/main/java/com/devsong/server/post/service/PostService.java
@@ -99,8 +99,10 @@ public class PostService {
 
     //카테고리별 게시글 목록 조회
     @Transactional(readOnly = true)
-    public List<PostListResponseDto> findByCategory(Category category) {
-        return postRepository.findAllByCategoryOrderByIdDesc(category).stream()
+    public List<PostListResponseDto> findByCategory(String category) {
+        Category categoryEnum = Category.from(category);
+        return postRepository.findAllByCategoryOrderByIdDesc(categoryEnum)
+                .stream()
                 .map(post -> PostListResponseDto.builder()
                         .id(post.getId())
                         .title(post.getTitle())


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
closed #31 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->
- 카테고리별 조회 API를 쿼리스트링 형식으로 변경
/post/category/project -> /post?category=project

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
<img width="519" height="81" alt="image" src="https://github.com/user-attachments/assets/e0520f92-c5e0-4c56-8d8f-8b4413204fa3" />


카테고리별 조회 엔드포인트를 RequestParam 방식으로 수정했습니다

<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!— 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) —>
https://ryusss.tistory.com/149

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 새로운 기능
  * 게시글 조회 API가 단일 엔드포인트(GET /post)로 통합되었습니다. category 쿼리 파라미터로 카테고리별 필터링이 가능하며(예: GET /post?category=tech), 미지정 시 전체 목록을 반환합니다.
* 리팩터링
  * 카테고리별 조회를 위한 별도 엔드포인트가 제거되어 호출 방식이 간소화되었습니다. 클라이언트는 쿼리 파라미터 기반 호출로 전환해야 합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->