### PR TITLE
[Fix] 게시물 상세조회 api response에 지원자 수 필드 추가

### DIFF
--- a/src/main/java/com/devsong/server/jwt/SecurityConfig.java
+++ b/src/main/java/com/devsong/server/jwt/SecurityConfig.java
@@ -19,7 +19,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
                         //회원가입, 로그인 api 요청은 토큰 없이 가능하도록 허용
-                        .requestMatchers("/user/signup", "/user/login").permitAll()
+                        .requestMatchers("/user/signup", "/user/login", "/user/check-email").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/devsong/server/post/dto/PostDetailResponseDto.java
+++ b/src/main/java/com/devsong/server/post/dto/PostDetailResponseDto.java
@@ -22,6 +22,7 @@ public class PostDetailResponseDto {
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime createdAt;
     private final boolean closed; //마감여부
+    private final Long applyCount; //지원자 수
     private final Long like; //좋아요 수
     private final Long comment; //댓글 수
     private final List<CommentResponseDto> comments; //댓글 리스트

--- a/src/main/java/com/devsong/server/post/repository/PostApplyRepository.java
+++ b/src/main/java/com/devsong/server/post/repository/PostApplyRepository.java
@@ -4,5 +4,6 @@ import com.devsong.server.post.entity.Post;
 import com.devsong.server.post.entity.PostApply;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PostApplyRepository extends JpaRepository<PostApply, Long> { ;
+public interface PostApplyRepository extends JpaRepository<PostApply, Long> {
+    Long countByPost(Post post);
 }

--- a/src/main/java/com/devsong/server/post/service/PostService.java
+++ b/src/main/java/com/devsong/server/post/service/PostService.java
@@ -21,6 +21,7 @@ public class PostService {
     private final UserRepository userRepository;
     private final PostLikeRepository postLikeRepository;
     private final CommentRepository commentRepository;
+    private final PostApplyRepository postApplyRepository;
 
     //게시글 등록
     @Transactional
@@ -63,6 +64,7 @@ public class PostService {
                 .major(post.getUser().getMajor())
                 .studentId(post.getUser().getStudentId())
                 .createdAt(post.getCreatedAt())
+                .applyCount(postApplyRepository.countByPost(post))
                 .closed(post.isClosed())
                 .like(
                         postLikeRepository.countByPostId(post.getId())

--- a/src/main/java/com/devsong/server/user/dto/EmailResponseDto.java
+++ b/src/main/java/com/devsong/server/user/dto/EmailResponseDto.java
@@ -6,5 +6,5 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class EmailResponseDto {
-    private boolean uniqueness;
+    private boolean available;
 }


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
closed #19

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->

- api 응답에 applyCount 필드 추가

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
### 수정된 api 테스트 결과
<img width="992" height="550" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/98c3dda1-97f7-48cc-81a8-3acfa85b92c1" />



<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!— 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) —>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 게시글 상세에 지원자 수가 추가되어 확인할 수 있습니다.

- 변경사항
  - 이메일 중복 확인 엔드포인트가 로그인 없이도 이용 가능해졌습니다.
  - 이메일 중복 확인 응답의 필드명이 uniqueness에서 available로 변경되었습니다. API 연동 시 필드명 변경에 유의하세요.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->