### PR TITLE
[Feat] 게시물 마감 기능 구현

### DIFF
--- a/src/main/java/com/devsong/server/post/controller/PostController.java
+++ b/src/main/java/com/devsong/server/post/controller/PostController.java
@@ -5,6 +5,8 @@ import com.devsong.server.post.entity.Category;
 import com.devsong.server.post.service.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -72,7 +74,16 @@ public class PostController {
     public ResponseEntity<PostCloseResponseDto> closePost(@PathVariable Long id) {
         PostCloseResponseDto response = postService.closePost(id);
         return ResponseEntity.ok(response);
-    }
 
-}
+        //지원자 목록 조회
+        @GetMapping("/{id}/applicantlist")
+        public ResponseEntity<List<PostApplicantListResponseDto>> getApplicants(@PathVariable("id") Long postId) {
+            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+            Long userId = (Long) auth.getPrincipal();
+
+            List<PostApplicantListResponseDto> applicants = postApplyService.getApplicants(postId, userId);
+            return ResponseEntity.ok(applicants);
+        }
+
+    }
 

--- a/src/main/java/com/devsong/server/post/controller/PostController.java
+++ b/src/main/java/com/devsong/server/post/controller/PostController.java
@@ -62,5 +62,12 @@ public class PostController {
         return ResponseEntity.ok(response);
     }
 
+    //게시글 마감하기
+    @PatchMapping("/{id}/close")
+    public ResponseEntity<Void> closePost(@PathVariable Long id) {
+        postService.closePost(id);
+        return ResponseEntity.ok().build();
+    }
+
 }
 

--- a/src/main/java/com/devsong/server/post/controller/PostController.java
+++ b/src/main/java/com/devsong/server/post/controller/PostController.java
@@ -68,10 +68,10 @@ public class PostController {
     }
 
     //게시글 마감하기
-    @PatchMapping("/{id}/close")
-    public ResponseEntity<Void> closePost(@PathVariable Long id) {
-        postService.closePost(id);
-        return ResponseEntity.ok().build();
+    @PostMapping("/{id}/close")
+    public ResponseEntity<PostCloseResponseDto> closePost(@PathVariable Long id) {
+        PostCloseResponseDto response = postService.closePost(id);
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/src/main/java/com/devsong/server/post/dto/PostCloseResponseDto.java
+++ b/src/main/java/com/devsong/server/post/dto/PostCloseResponseDto.java
@@ -1,0 +1,15 @@
+package com.devsong.server.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class PostCloseResponseDto {
+    private String username;
+    private boolean closed;
+}

--- a/src/main/java/com/devsong/server/post/entity/Post.java
+++ b/src/main/java/com/devsong/server/post/entity/Post.java
@@ -11,6 +11,7 @@ import java.util.List;
 @Builder
 @Entity
 @Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post {

--- a/src/main/java/com/devsong/server/post/entity/Post.java
+++ b/src/main/java/com/devsong/server/post/entity/Post.java
@@ -11,7 +11,6 @@ import java.util.List;
 @Builder
 @Entity
 @Getter
-@Setter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post {
@@ -31,6 +30,7 @@ public class Post {
     @Enumerated(EnumType.STRING)
     private Category category; //카테고리
 
+    @Setter
     private boolean closed; //마감여부
 
     private LocalDateTime createdAt; //작성시각

--- a/src/main/java/com/devsong/server/post/service/CommentService.java
+++ b/src/main/java/com/devsong/server/post/service/CommentService.java
@@ -30,7 +30,7 @@ public class CommentService {
         Long userId = (Long) auth.getPrincipal();
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("유저 정보를 찾을 수 없습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
         Post post = postRepository.findById(dto.getPostId())
                 .orElseThrow(() -> new RuntimeException("Post not found"));

--- a/src/main/java/com/devsong/server/post/service/CommentService.java
+++ b/src/main/java/com/devsong/server/post/service/CommentService.java
@@ -10,9 +10,11 @@ import com.devsong.server.user.entity.User;
 import com.devsong.server.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 @Service
 @RequiredArgsConstructor
@@ -30,10 +32,10 @@ public class CommentService {
         Long userId = (Long) auth.getPrincipal();
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
 
         Post post = postRepository.findById(dto.getPostId())
-                .orElseThrow(() -> new RuntimeException("Post not found"));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Post not found"));
 
         Comment comment = Comment.builder()
                 .user(user)

--- a/src/main/java/com/devsong/server/post/service/PostApplyService.java
+++ b/src/main/java/com/devsong/server/post/service/PostApplyService.java
@@ -26,13 +26,18 @@ public class PostApplyService {
 
         //jwt로 유저 정보 얻기
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) auth.getPrincipal();
+        Long principal = (Long) auth.getPrincipal();
 
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("유저 정보를 찾을 수 없습니다."));
+
+        User user = userRepository.findById(principal)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
         Post post = postRepository.findById(dto.getPostId())
                 .orElseThrow(() -> new RuntimeException("Post not found"));
+
+        if (post.isClosed()) {
+            throw new IllegalStateException("Post closed");
+        }
 
         PostApply postApply = PostApply.builder()
                 .user(user)

--- a/src/main/java/com/devsong/server/post/service/PostApplyService.java
+++ b/src/main/java/com/devsong/server/post/service/PostApplyService.java
@@ -10,9 +10,11 @@ import com.devsong.server.user.entity.User;
 import com.devsong.server.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 @Service
 @RequiredArgsConstructor
@@ -26,14 +28,14 @@ public class PostApplyService {
 
         //jwt로 유저 정보 얻기
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        Long principal = (Long) auth.getPrincipal();
+        Long userId = (Long) auth.getPrincipal();
 
 
-        User user = userRepository.findById(principal)
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
 
         Post post = postRepository.findById(dto.getPostId())
-                .orElseThrow(() -> new RuntimeException("Post not found"));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
 
         if (post.isClosed()) {
             throw new IllegalStateException("Post closed");

--- a/src/main/java/com/devsong/server/post/service/PostApplyService.java
+++ b/src/main/java/com/devsong/server/post/service/PostApplyService.java
@@ -35,7 +35,7 @@ public class PostApplyService {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
 
         Post post = postRepository.findById(dto.getPostId())
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Post not found"));
 
         if (post.isClosed()) {
             throw new IllegalStateException("Post closed");

--- a/src/main/java/com/devsong/server/post/service/PostLikeService.java
+++ b/src/main/java/com/devsong/server/post/service/PostLikeService.java
@@ -30,7 +30,7 @@ public class PostLikeService {
         Long userId = (Long) auth.getPrincipal();
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("유저 정보를 찾을 수 없습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
         boolean exists = postLikeRepository.existsByUserIdAndPostId(userId, dto.getPostId());
 

--- a/src/main/java/com/devsong/server/post/service/PostLikeService.java
+++ b/src/main/java/com/devsong/server/post/service/PostLikeService.java
@@ -10,9 +10,11 @@ import com.devsong.server.user.entity.User;
 import com.devsong.server.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 @Service
 @RequiredArgsConstructor
@@ -30,7 +32,7 @@ public class PostLikeService {
         Long userId = (Long) auth.getPrincipal();
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
 
         boolean exists = postLikeRepository.existsByUserIdAndPostId(userId, dto.getPostId());
 
@@ -41,7 +43,7 @@ public class PostLikeService {
                     .build();
         } else {
             Post post = postRepository.findById(dto.getPostId())
-                    .orElseThrow(() -> new RuntimeException("Post not found"));
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Post not found"));
 
             PostLike postLike = PostLike.builder()
                     .user(user)

--- a/src/main/java/com/devsong/server/post/service/PostService.java
+++ b/src/main/java/com/devsong/server/post/service/PostService.java
@@ -99,4 +99,17 @@ public class PostService {
         if (content == null) return "";
         return content.length() > limit ? content.substring(0, limit) + "..." : content;
     }
+
+    //게시글 마감
+    @Transactional
+    public void closePost(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));
+
+        if (post.isClosed()) {
+            throw new IllegalStateException("이미 마감된 게시물입니다.");
+        }
+
+        post.setClosed(true);
+    }
 }

--- a/src/main/java/com/devsong/server/post/service/PostService.java
+++ b/src/main/java/com/devsong/server/post/service/PostService.java
@@ -32,7 +32,7 @@ public class PostService {
         Long userId = (Long) auth.getPrincipal();
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("유저 정보를 찾을 수 없습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
         //RequestDto -> Entity 변환
         Post post = Post.builder()
@@ -52,7 +52,7 @@ public class PostService {
     @Transactional(readOnly = true)
     public PostDetailResponseDto findPost(Long id) {
         Post post = postRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("Post not found"));
 
         //Entity -> ResponseDto 변환
         return PostDetailResponseDto.builder()
@@ -139,15 +139,26 @@ public class PostService {
 
     //게시글 마감
     @Transactional
-    public void closePost(Long postId) {
+    public PostCloseResponseDto closePost(Long postId) {
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("Post not found"));
 
         if (post.isClosed()) {
-            throw new IllegalStateException("이미 마감된 게시물입니다.");
+            throw new IllegalStateException("Post closed");
         }
 
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = (Long) auth.getPrincipal();
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
         post.setClosed(true);
+
+        return PostCloseResponseDto.builder()
+                .username(user.getUsername())
+                .closed(true)
+                .build();
     }
 }
 

--- a/src/main/java/com/devsong/server/post/service/PostService.java
+++ b/src/main/java/com/devsong/server/post/service/PostService.java
@@ -4,6 +4,7 @@ import com.devsong.server.post.dto.*;
 import com.devsong.server.post.entity.Category;
 import com.devsong.server.post.entity.Post;
 import com.devsong.server.user.entity.User;
+import com.devsong.server.post.entity.Comment;
 import com.devsong.server.post.repository.*;
 import com.devsong.server.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -55,6 +56,13 @@ public class PostService {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Post not found"));
 
+        List<Comment> comments = commentRepository.findByPostId(id);
+
+        List<CommentResponseDto> commentDtos = comments.stream()
+                .filter(c -> c.getParent() == null)
+                .map(c -> toDto(c, comments))
+                .toList();
+
         //Entity -> ResponseDto 변환
         return PostDetailResponseDto.builder()
                 .id(post.getId())
@@ -73,16 +81,7 @@ public class PostService {
                 .comment(
                         commentRepository.countByPostId(post.getId())
                 )
-                .comments(
-                        commentRepository.findByPostId(post.getId()).stream()
-                                .map(comment -> CommentResponseDto.builder()
-                                        .commentId(comment.getId())
-                                        .username(comment.getUser().getUsername())
-                                        .content(comment.getContent())
-                                        .createdAt(comment.getCreatedAt())
-                                        .build()
-                                ).toList()
-                )
+                .comments(commentDtos)
                 .build();
     }
 
@@ -92,19 +91,19 @@ public class PostService {
     public List<PostListResponseDto> findAll() {
         return postRepository.findAllByOrderByIdDesc().stream()
                 .map(post -> PostListResponseDto.builder()
-                                .id(post.getId())
-                                .title(post.getTitle())
-                                .username(post.getUser().getUsername())
-                                .preview(preview(post.getContent(), 80))
-                                .createdAt(post.getCreatedAt())
-                                .closed(post.isClosed())
-                                .like(
-                                        postLikeRepository.countByPostId(post.getId())
-                                )
-                                .comment(
-                                        commentRepository.countByPostId(post.getId())
-                                )
-                                .build()
+                        .id(post.getId())
+                        .title(post.getTitle())
+                        .username(post.getUser().getUsername())
+                        .preview(preview(post.getContent(), 80))
+                        .createdAt(post.getCreatedAt())
+                        .closed(post.isClosed())
+                        .like(
+                                postLikeRepository.countByPostId(post.getId())
+                        )
+                        .comment(
+                                commentRepository.countByPostId(post.getId())
+                        )
+                        .build()
                 )
                 .toList();
     }
@@ -178,6 +177,24 @@ public class PostService {
                 .closed(true)
                 .build();
     }
+
+    private CommentResponseDto toDto(Comment comment, List<Comment> allComments) {
+        // 현재 댓글의 자식 찾기
+        List<CommentResponseDto> children = allComments.stream()
+                .filter(c -> c.getParent() != null && c.getParent().getId().equals(comment.getId()))
+                .map(c -> toDto(c, allComments)) // 재귀 호출
+                .toList();
+
+        return CommentResponseDto.builder()
+                .commentId(comment.getId())
+                .username(comment.getUser().getUsername())
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt())
+                .parentId(comment.getParent() != null ? comment.getParent().getId() : null)
+                .children(children.isEmpty() ? null : children)
+                .build();
+    }
+
 }
 
 

--- a/src/main/java/com/devsong/server/post/service/PostService.java
+++ b/src/main/java/com/devsong/server/post/service/PostService.java
@@ -7,10 +7,12 @@ import com.devsong.server.user.entity.User;
 import com.devsong.server.post.repository.*;
 import com.devsong.server.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -32,8 +34,7 @@ public class PostService {
         Long userId = (Long) auth.getPrincipal();
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
-
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
         //RequestDto -> Entity 변환
         Post post = Post.builder()
                 .title(requestDto.getTitle())
@@ -52,7 +53,7 @@ public class PostService {
     @Transactional(readOnly = true)
     public PostDetailResponseDto findPost(Long id) {
         Post post = postRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("Post not found"));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Post not found"));
 
         //Entity -> ResponseDto 변환
         return PostDetailResponseDto.builder()
@@ -144,14 +145,31 @@ public class PostService {
                 .orElseThrow(() -> new IllegalArgumentException("Post not found"));
 
         if (post.isClosed()) {
-            throw new IllegalStateException("Post closed");
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Post already closed");
         }
 
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) auth.getPrincipal();
+        if (auth == null || auth.getPrincipal() == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Unauthenticated");
+        }
+
+        Object principal = auth.getPrincipal();
+        Long userId;
+
+        if (principal instanceof Long l) {
+            userId = l;
+        } else if (principal instanceof org.springframework.security.core.userdetails.UserDetails ud) {
+            userId = Long.parseLong(ud.getUsername());
+        } else {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid principal");
+        }
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+
+        if (!post.getUser().getId().equals(user.getId())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Not authorized to close this post");
+        }
 
         post.setClosed(true);
 


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
closed #20 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->

-게시물 마감 기능 구현
-게시물 마감 시 해당 게시물에 apply 할 수 없음
-Service 단의 예외처리 메세지 통일 (Post not found, User not found, Post closed)

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
글 마감 시
<img width="519" height="284" alt="image" src="https://github.com/user-attachments/assets/df5499c7-43db-4f7e-8df4-2177d5525d9b" />

<img width="813" height="89" alt="image" src="https://github.com/user-attachments/assets/7d2b987b-86ea-4730-81db-d21e3af6f938" />

db에 마감 여부 정상적으로 등록되는 것 확인했습니다
<img width="1805" height="726" alt="image" src="https://github.com/user-attachments/assets/aa7b8fa4-c024-47db-aa98-346bc5deb8aa" />

이부분 에러는 아니고 정상적으로 지원 막힌 상태입니다!

<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!— 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) —>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 작성자가 게시글을 명시적으로 닫을 수 있는 기능 추가 (POST /post/{id}/close). 응답에 작성자명과 closed 상태 포함.
* **Bug Fixes**
  * 닫힌 게시글에 대한 신청/참여 차단 로직 강화 및 이미 닫힌 게시글에 대한 충돌 처리 개선.
* **Chores**
  * 오류 응답을 HTTP 상태 기반으로 정리하고 메시지를 영어로 표준화. 인증·인가 검증 강화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->