### PR TITLE
[Fix] 게시물 전체조회 api 응답에 카테고리 필드 추가

### DIFF
--- a/src/main/java/com/devsong/server/post/dto/PostListResponseDto.java
+++ b/src/main/java/com/devsong/server/post/dto/PostListResponseDto.java
@@ -14,6 +14,7 @@ public class PostListResponseDto {
     private final Long id;
     private final String title;
     private final String username;
+    private final String category;
     private final String preview;
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime createdAt;

--- a/src/main/java/com/devsong/server/post/service/PostService.java
+++ b/src/main/java/com/devsong/server/post/service/PostService.java
@@ -93,6 +93,7 @@ public class PostService {
                                 .id(post.getId())
                                 .title(post.getTitle())
                                 .username(post.getUser().getUsername())
+                                .category(post.getCategory().toString())
                                 .preview(preview(post.getContent(), 80))
                                 .createdAt(post.getCreatedAt())
                                 .closed(post.isClosed())


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
closed #37

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->


<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!— 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) —>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 새 기능
  * 게시글 목록 응답에 카테고리 정보가 추가되어 각 게시글의 카테고리를 확인할 수 있습니다.
  * 목록 화면/컴포넌트에서 카테고리를 표시하면 사용자에게 카테고리 배지가 노출됩니다.
  * 기존 응답 필드는 유지되어 하위 호환성이 보장되며, 기존 클라이언트는 추가 필드를 무시해도 정상 동작합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->