### PR TITLE
[Fix] 게시물 상세조회 api 응답 수정

### DIFF
--- a/src/main/java/com/devsong/server/post/controller/PostController.java
+++ b/src/main/java/com/devsong/server/post/controller/PostController.java
@@ -31,9 +31,12 @@ public class PostController {
 
 
     //게시글 상세정보 조회
-    @GetMapping("/{id}")
-    public ResponseEntity<PostDetailResponseDto> getPost(@PathVariable Long id) {
-        PostDetailResponseDto responseDto = postService.findPost(id);
+    @GetMapping("/{postId}")
+    public ResponseEntity<PostDetailResponseDto> getPost(@PathVariable Long postId) {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication(); //jwt에서 유저 정보 가져오기
+        Long userId = (Long) auth.getPrincipal();
+
+        PostDetailResponseDto responseDto = postService.findPost(postId, userId);
         return ResponseEntity.ok(responseDto);
     }
 

--- a/src/main/java/com/devsong/server/post/dto/PostDetailResponseDto.java
+++ b/src/main/java/com/devsong/server/post/dto/PostDetailResponseDto.java
@@ -12,6 +12,10 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 public class PostDetailResponseDto {
+    private boolean author; //내가 쓴 글인지
+    private boolean liked; //좋아요 여부
+    private boolean applied; //지원 여부
+
     private final Long id;
     private final String title;
     private final String username;

--- a/src/main/java/com/devsong/server/post/repository/PostApplyRepository.java
+++ b/src/main/java/com/devsong/server/post/repository/PostApplyRepository.java
@@ -10,4 +10,6 @@ public interface PostApplyRepository extends JpaRepository<PostApply, Long> {
 
     //지원자 목록 불러오기
     List<PostApply> findByPostId(Long postId);
+
+    boolean existsByPostIdAndUserId(Long postId, Long userId);
 }

--- a/src/main/java/com/devsong/server/post/service/PostService.java
+++ b/src/main/java/com/devsong/server/post/service/PostService.java
@@ -52,11 +52,11 @@ public class PostService {
 
     //게시글 상세정보 조회 (없을 시 코멘트 출력)
     @Transactional(readOnly = true)
-    public PostDetailResponseDto findPost(Long id) {
-        Post post = postRepository.findById(id)
+    public PostDetailResponseDto findPost(Long postId, Long userId) {
+        Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Post not found"));
 
-        List<Comment> comments = commentRepository.findByPostId(id);
+        List<Comment> comments = commentRepository.findByPostId(postId);
 
         List<CommentResponseDto> commentDtos = comments.stream()
                 .filter(c -> c.getParent() == null)
@@ -65,7 +65,10 @@ public class PostService {
 
         //Entity -> ResponseDto 변환
         return PostDetailResponseDto.builder()
-                .id(post.getId())
+                .author(post.getUser().getId().equals(userId))
+                .liked(postLikeRepository.existsByUserIdAndPostId(userId, postId))
+                .applied(postApplyRepository.existsByPostIdAndUserId(postId, userId))
+                .id(postId)
                 .title(post.getTitle())
                 .username(post.getUser().getUsername())
                 .content(post.getContent())
@@ -76,10 +79,10 @@ public class PostService {
                 .applyCount(postApplyRepository.countByPost(post))
                 .closed(post.isClosed())
                 .like(
-                        postLikeRepository.countByPostId(post.getId())
+                        postLikeRepository.countByPostId(postId)
                 )
                 .comment(
-                        commentRepository.countByPostId(post.getId())
+                        commentRepository.countByPostId(postId)
                 )
                 .comments(commentDtos)
                 .build();


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
closed #41 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->
응답에 내 글인지, 좋아요 눌렀는지, 지원했는지 여부 표시되도록 수정함
author, liked, applied 필드 추가

api 명세서 수정 완료

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
<img width="1066" height="545" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/e532a901-e817-488c-b08b-111b447c7d84" />


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!— 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) —>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 게시글 상세에 사용자별 상태가 추가되었습니다: 내가 작성자인지, 좋아요를 눌렀는지, 신청했는지 여부를 확인할 수 있습니다.
  * 로그인된 사용자 기준으로 개인화된 상세 정보를 제공합니다.

* 변경 사항
  * 게시글 상세 조회가 사용자 컨텍스트를 반영하도록 개선되어, 응답에 위 상태 값들이 포함됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->