### PR TITLE
[Feat] 현재 인기글 조회 (베스트 글 불러오기) 기능 구현

### DIFF
--- a/src/main/java/com/devsong/server/post/controller/PostController.java
+++ b/src/main/java/com/devsong/server/post/controller/PostController.java
@@ -89,6 +89,12 @@ public class PostController {
         return ResponseEntity.ok(response);
     }
 
+    //현재 인기글 조회 (베스트 글 불러오기)
+    @GetMapping("/best")
+    public ResponseEntity<List<PostBestResponseDto>> getBestPosts() {
+        List<PostBestResponseDto> bestPosts = postService.findBestPosts();
+        return ResponseEntity.ok(bestPosts);
+    }
 }
 
 

--- a/src/main/java/com/devsong/server/post/dto/PostBestResponseDto.java
+++ b/src/main/java/com/devsong/server/post/dto/PostBestResponseDto.java
@@ -1,0 +1,15 @@
+package com.devsong.server.post.dto;
+
+import com.devsong.server.post.entity.Category;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PostBestResponseDto {
+    private Long postId;
+    private String title;
+    private String preview;
+    private Category category;
+    private boolean closed;
+}

--- a/src/main/java/com/devsong/server/post/repository/PostRepository.java
+++ b/src/main/java/com/devsong/server/post/repository/PostRepository.java
@@ -2,11 +2,17 @@ package com.devsong.server.post.repository;
 
 import com.devsong.server.post.entity.Category;
 import com.devsong.server.post.entity.Post;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findAllByOrderByIdDesc(); //전체조회
     List<Post> findAllByCategoryOrderByIdDesc(Category category); //카테고리별 조회
+    @Query("SELECT p FROM Post p LEFT JOIN PostLike pl ON p.id = pl.post.id " +
+            "GROUP BY p.id " +
+            "ORDER BY COUNT(pl.id) DESC")
+    List<Post> findByLikeCountDesc(Pageable pageable); //좋아요 상위 9개 게시글 조회
 }

--- a/src/main/java/com/devsong/server/post/service/PostService.java
+++ b/src/main/java/com/devsong/server/post/service/PostService.java
@@ -200,5 +200,19 @@ public class PostService {
                 .build();
     }
 
+    @Transactional(readOnly = true)
+    public List<PostBestResponseDto> findBestPosts() {
+        return postRepository.findByLikeCountDesc(org.springframework.data.domain.PageRequest.of(0, 9)).stream()
+                .map(post -> PostBestResponseDto.builder()
+                        .postId(post.getId())
+                        .title(post.getTitle())
+                        .preview(preview(post.getContent(), 150))
+                        .category(post.getCategory())
+                        .closed(post.isClosed())
+                        .build()
+                )
+                .toList();
+    }
+
 }
 


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
closed #39 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->
- 인기글 조회 API 구현
- 좋아요 수 기준 상위 9개 게시글 조회
- 반환 DTO에 필요한 필드만 포함 (postId, title, preview, category, closed)
- preview 필드 content에서 최대 150글자까지만 추출하도록 제한
- api 명세서 수정 완료
<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!— 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) —>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 좋아요 수 기준으로 정렬된 인기 게시글 상위 9개를 반환하는 조회 API가 추가되었습니다.
  * 응답에는 게시글 ID, 제목, 150자 미리보기, 카테고리, 마감 여부가 포함되어 목록형 UI에 바로 활용할 수 있습니다.
  * 별도 필터 없이 호출해 베스트 게시글을 빠르게 노출할 수 있어, 홈/추천 섹션 구현에 유용합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->