### PR TITLE
[Feat] 내가 쓴 글, 댓글 단 글, 좋아요한 글, 지원한 글 조회 기능 구현

### DIFF
--- a/src/main/java/com/devsong/server/post/repository/CommentRepository.java
+++ b/src/main/java/com/devsong/server/post/repository/CommentRepository.java
@@ -13,4 +13,5 @@ import java.util.List;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     Long countByPostId(Long postId);
     List<Comment> findByPostId(Long postId);
+    List<Comment> findByUserIdOrderByIdDesc(Long userId); // 내가 댓글 단 글 조회
 }

--- a/src/main/java/com/devsong/server/post/repository/PostApplyRepository.java
+++ b/src/main/java/com/devsong/server/post/repository/PostApplyRepository.java
@@ -12,4 +12,6 @@ public interface PostApplyRepository extends JpaRepository<PostApply, Long> {
     List<PostApply> findByPostId(Long postId);
 
     boolean existsByPostIdAndUserId(Long postId, Long userId);
+
+    List<PostApply> findByUserId(Long userId); //내가 지원한 글 조회
 }

--- a/src/main/java/com/devsong/server/post/repository/PostLikeRepository.java
+++ b/src/main/java/com/devsong/server/post/repository/PostLikeRepository.java
@@ -5,9 +5,12 @@ import com.devsong.server.post.entity.PostLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PostLikeRepository extends JpaRepository<PostLike, Long>  {
     boolean existsByUserIdAndPostId(Long userId, Long postId);
     void deleteByUserIdAndPostId(Long userId, Long postId);
     Long countByPostId(Long postId);
+    List<PostLike> findByUserId(Long userId); //내가 좋아요한 글 조회
 }

--- a/src/main/java/com/devsong/server/post/repository/PostRepository.java
+++ b/src/main/java/com/devsong/server/post/repository/PostRepository.java
@@ -15,4 +15,5 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             "GROUP BY p.id " +
             "ORDER BY COUNT(pl.id) DESC")
     List<Post> findByLikeCountDesc(Pageable pageable); //좋아요 상위 9개 게시글 조회
+    List<Post> findByUserIdOrderByIdDesc(Long userId); //내가 쓴 글 조회
 }

--- a/src/main/java/com/devsong/server/user/controller/UserController.java
+++ b/src/main/java/com/devsong/server/user/controller/UserController.java
@@ -4,6 +4,8 @@ import com.devsong.server.user.dto.*;
 import com.devsong.server.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,5 +27,25 @@ public class UserController {
     @PostMapping("/check-email") //이메일 중복확인
     public EmailResponseDto checkEmail(@RequestBody EmailRequestDto emailRequestDto) {
         return userService.checkEmail(emailRequestDto);
+    }
+
+    @GetMapping("/me/posts")
+    public List<MyPostDto> getMyPosts(@AuthenticationPrincipal Long userId) {
+        return userService.getMyPosts(userId);
+    }
+
+    @GetMapping("/me/comments")
+    public List<MyPostDto> getMyCommentedPosts(@AuthenticationPrincipal Long userId) {
+        return userService.getMyCommentedPosts(userId);
+    }
+
+    @GetMapping("/me/likes")
+    public List<MyPostDto> getMyLikedPosts(@AuthenticationPrincipal Long userId) {
+        return userService.getMyLikedPosts(userId);
+    }
+
+    @GetMapping("/me/applies")
+    public List<MyPostDto> getMyAppliedPosts(@AuthenticationPrincipal Long userId) {
+        return userService.getMyAppliedPosts(userId);
     }
 }

--- a/src/main/java/com/devsong/server/user/dto/MyPostDto.java
+++ b/src/main/java/com/devsong/server/user/dto/MyPostDto.java
@@ -1,0 +1,25 @@
+package com.devsong.server.user.dto;
+import com.devsong.server.post.entity.Category;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MyPostDto {
+    private final Long postId;
+    private final String title;      // 제목
+    private final String preview;    // 미리보기
+    private final Category category; // 카테고리
+    private final String username;   // 작성자 이름
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private final LocalDateTime createdAt;  // 작성 시간
+
+    private final boolean closed;   // 모집 마감 여부
+    private final Long like;        // 좋아요 수
+    private final Long comment;     // 댓글 수
+}

--- a/src/main/java/com/devsong/server/user/service/UserService.java
+++ b/src/main/java/com/devsong/server/user/service/UserService.java
@@ -6,6 +6,10 @@ import com.devsong.server.user.entity.User;
 import com.devsong.server.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import com.devsong.server.post.entity.*;
+import com.devsong.server.post.repository.*;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import java.util.UUID;
 
@@ -16,6 +20,11 @@ public class UserService {
     //DI
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
+
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+    private final PostLikeRepository postLikeRepository;
+    private final PostApplyRepository postApplyRepository;
 
     // 회원가입
     public SignupResponseDto signup(SignupRequestDto signupRequestDto) {
@@ -71,5 +80,83 @@ public class UserService {
     public EmailResponseDto checkEmail(EmailRequestDto emailRequestDto) {
         boolean isExist = (userRepository.findByEmail(emailRequestDto.getEmail()) != null);
         return new EmailResponseDto(!isExist);
+    }
+
+    private String preview(String content, int limit) {
+        if (content == null) return "";
+        return content.length() > limit ? content.substring(0, limit) + "..." : content;
+    }
+
+    // 내가 쓴 글
+    public List<MyPostDto> getMyPosts(Long userId) {
+        return postRepository.findByUserIdOrderByIdDesc(userId).stream()
+                .map(post -> MyPostDto.builder()
+                        .postId(post.getId())
+                        .title(post.getTitle())
+                        .preview(preview(post.getContent(), 35))
+                        .category(post.getCategory())
+                        .username(post.getUser().getUsername())
+                        .createdAt(post.getCreatedAt())
+                        .closed(post.isClosed())
+                        .like(postLikeRepository.countByPostId(post.getId()))
+                        .comment(commentRepository.countByPostId(post.getId()))
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    // 내가 댓글 단 글
+    public List<MyPostDto> getMyCommentedPosts(Long userId) {
+        return commentRepository.findByUserIdOrderByIdDesc(userId).stream()
+                .map(comment -> {
+                    var post = comment.getPost();
+                    return MyPostDto.builder()
+                            .postId(post.getId())
+                            .title(post.getTitle())
+                            .preview(preview(post.getContent(), 35))
+                            .category(post.getCategory())
+                            .username(post.getUser().getUsername())
+                            .createdAt(post.getCreatedAt())
+                            .closed(post.isClosed())
+                            .like(postLikeRepository.countByPostId(post.getId()))
+                            .comment(commentRepository.countByPostId(post.getId()))
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
+
+    // 내가 좋아요한 글
+    public List<MyPostDto> getMyLikedPosts(Long userId) {
+        return postLikeRepository.findByUserId(userId).stream()
+                .map(PostLike::getPost)
+                .map(post -> MyPostDto.builder()
+                        .postId(post.getId())
+                        .title(post.getTitle())
+                        .preview(preview(post.getContent(), 35))
+                        .category(post.getCategory())
+                        .username(post.getUser().getUsername())
+                        .createdAt(post.getCreatedAt())
+                        .closed(post.isClosed())
+                        .like(postLikeRepository.countByPostId(post.getId()))
+                        .comment(commentRepository.countByPostId(post.getId()))
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    // 내가 지원한 글
+    public List<MyPostDto> getMyAppliedPosts(Long userId) {
+        return postApplyRepository.findByUserId(userId).stream()
+                .map(PostApply::getPost)
+                .map(post -> MyPostDto.builder()
+                        .postId(post.getId())
+                        .title(post.getTitle())
+                        .preview(preview(post.getContent(), 35))
+                        .category(post.getCategory())
+                        .username(post.getUser().getUsername())
+                        .createdAt(post.getCreatedAt())
+                        .closed(post.isClosed())
+                        .like(postLikeRepository.countByPostId(post.getId()))
+                        .comment(commentRepository.countByPostId(post.getId()))
+                        .build())
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
closed #45

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->
- 내가 쓴 글, 댓글 단 글, 좋아요한 글, 지원한 글 조회 기능 구현
- API 명세서 업데이트

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!— 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) —>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 내 활동 조회 기능 추가: 내가 작성한 글, 댓글 남긴 글, 좋아요한 글, 지원한 글 목록을 확인할 수 있습니다.
  - 각 목록은 최신순으로 제공되며 제목, 미리보기, 카테고리, 작성자, 작성일, 마감 여부, 좋아요 수, 댓글 수 정보를 포함합니다.
  - 인증된 사용자 전용 엔드포인트 제공: /user/me/posts, /user/me/comments, /user/me/likes, /user/me/applies


<!-- end of auto-generated comment: release notes by coderabbit.ai -->