### PR TITLE
[Feat] 카테고리, 정렬, 페이지, 모집마감 여부 기반 게시글 조회

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.gitignore
+.gradle
+build
+*.iml
+.idea
+.vscode
+node_modules/
+.DS_Store
+Thumbs.db
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# Build stage
+FROM gradle:8.9-jdk21 AS builder
+WORKDIR /app
+COPY . .
+RUN ./gradlew clean build -x test --no-daemon --refresh-dependencies
+
+# Run stage
+FROM openjdk:21-jdk-slim
+WORKDIR /app
+COPY --from=builder /app/build/libs/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+services:
+  backend:
+    build: .
+    container_name: devsong
+    ports:
+      - "8080:8080"
+    restart: unless-stopped
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://devsong_db:3306/devsong_db?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&serverTimezone=UTC
+      SPRING_DATASOURCE_USERNAME: user
+      SPRING_DATASOURCE_PASSWORD: user123
+      SPRING_JPA_HIBERNATE_DDL_AUTO: update
+    depends_on:
+      - devsong_db
+    networks:
+      - spring-network
+
+  devsong_db:
+    image: mysql:8.0
+    container_name: devsong_db
+    restart: always
+    ports:
+      - "3307:3306"
+    volumes:
+      - db_data:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: asdf6304@
+      MYSQL_DATABASE: devsong_db
+    networks:
+      - spring-network
+
+volumes:
+  db_data:
+
+networks:
+  spring-network:

--- a/src/main/java/com/devsong/server/post/controller/PostController.java
+++ b/src/main/java/com/devsong/server/post/controller/PostController.java
@@ -47,13 +47,16 @@ public class PostController {
 
     //게시글 목록 조회
     @GetMapping
-    public ResponseEntity<PostPageResponseDto> findAll(@RequestParam(required = false) String category,
+    public ResponseEntity<PostPageResponseDto> findAll(
+            @RequestParam(required = false) String category,
             @RequestParam(defaultValue = "createdAt") String sortBy,
-            @RequestParam(defaultValue = "0") int page // 페이지 번호, 기본값 0
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(required = false) Boolean closed
     ) {
-        PostPageResponseDto response = postService.findPosts(category, sortBy, page);
+        PostPageResponseDto response = postService.findPosts(category, sortBy, page, closed); // 카테고리, 최신순인지 좋아요순인지, 몇 페이지인지, 모집마감 여부
         return ResponseEntity.ok(response);
     }
+
 
     //게시글 댓글 작성
     @PostMapping("/comment")

--- a/src/main/java/com/devsong/server/post/repository/PostRepository.java
+++ b/src/main/java/com/devsong/server/post/repository/PostRepository.java
@@ -24,4 +24,17 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     // 내가 쓴 글 조회
     List<Post> findByUserIdOrderByIdDesc(Long userId);
+
+    // 모집여부별 조회 - 최신순
+    Page<Post> findAllByClosedOrderByCreatedAtDesc(boolean closed, Pageable pageable);
+
+    // 모집여부별 조회 - 좋아요순
+    Page<Post> findAllByClosedOrderByLikeCountDesc(boolean closed, Pageable pageable);
+
+    // 카테고리+모집여부별 조회 - 최신순
+    Page<Post> findAllByCategoryAndClosedOrderByCreatedAtDesc(Category category, boolean closed, Pageable pageable);
+
+    // 카테고리+모집여부별 조회 - 좋아요순
+    Page<Post> findAllByCategoryAndClosedOrderByLikeCountDesc(Category category, boolean closed, Pageable pageable);
+
 }

--- a/src/main/java/com/devsong/server/post/service/PostService.java
+++ b/src/main/java/com/devsong/server/post/service/PostService.java
@@ -97,23 +97,34 @@ public class PostService {
 
     //게시글 목록 조회
     @Transactional(readOnly = true)
-    public PostPageResponseDto findPosts(String category, String sortBy, int page) {
+    public PostPageResponseDto findPosts(String category, String sortBy, int page, Boolean closed) {
         Pageable pageable = PageRequest.of(page, 10); // 한 페이지당 10개 고정
 
         Page<Post> posts;
         boolean sortByLike = "like".equalsIgnoreCase(sortBy);
 
-        if (category == null || category.isEmpty()) {
-            // 전체 게시글 조회
-            posts = sortByLike
-                    ? postRepository.findAllByOrderByLikeCountDesc(pageable)
-                    : postRepository.findAllByOrderByCreatedAtDesc(pageable);
+        if (closed == null) {
+            if (category == null || category.isEmpty()) {
+                posts = sortByLike
+                        ? postRepository.findAllByOrderByLikeCountDesc(pageable)
+                        : postRepository.findAllByOrderByCreatedAtDesc(pageable);
+            } else {
+                Category categoryEnum = Category.from(category);
+                posts = sortByLike
+                        ? postRepository.findAllByCategoryOrderByLikeCountDesc(categoryEnum, pageable)
+                        : postRepository.findAllByCategoryOrderByCreatedAtDesc(categoryEnum, pageable);
+            }
         } else {
-            // 카테고리별 게시글 조회
-            Category categoryEnum = Category.from(category);
-            posts = sortByLike
-                    ? postRepository.findAllByCategoryOrderByLikeCountDesc(categoryEnum, pageable)
-                    : postRepository.findAllByCategoryOrderByCreatedAtDesc(categoryEnum, pageable);
+            if (category == null || category.isEmpty()) {
+                posts = sortByLike
+                        ? postRepository.findAllByClosedOrderByLikeCountDesc(closed, pageable)
+                        : postRepository.findAllByClosedOrderByCreatedAtDesc(closed, pageable);
+            } else {
+                Category categoryEnum = Category.from(category);
+                posts = sortByLike
+                        ? postRepository.findAllByCategoryAndClosedOrderByLikeCountDesc(categoryEnum, closed, pageable)
+                        : postRepository.findAllByCategoryAndClosedOrderByCreatedAtDesc(categoryEnum, closed, pageable);
+            }
         }
 
         // 게시글 DTO로 변환


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#58 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->
원래는 모집마감 여부로만 필터링하는 기능을 구현 예정이었으나,
로직을 통합하면서 카테고리, 정렬 기준, 페이지까지 함께 처리하도록 확장했습니다.
이에 따라 PostService와 PostRepository의 조회 로직을 통합 및 개선했습니다!!


수정 사항
- `PostService.findPosts()` 메서드 리팩토링: category, sortBy, closed, page 파라미터 기반 조회
- `PostRepository` 메서드 추가: 카테고리·모집여부별 조회 (최신순 / 좋아요순)
- Controller에서 필터 파라미터 수용 및 API 엔드포인트 연동

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!— 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) —>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리즈 노트

* **New Features**
  * 모집 상태 필터링 기능 추가: 게시물을 모집 중/마감 상태로 필터링할 수 있습니다.

* **Chores**
  * Docker 및 Docker Compose 설정 추가: 애플리케이션 배포를 위한 컨테이너화 구성이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->