### PR TITLE
[Fix] 이력서 페이지에 깃허브 아이디, 백준 아이디 수정 기능 추가

### DIFF
--- a/src/main/java/com/devsong/server/user/dto/UpdateResumeRequestDto.java
+++ b/src/main/java/com/devsong/server/user/dto/UpdateResumeRequestDto.java
@@ -11,6 +11,8 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UpdateResumeRequestDto {
+    private String bojId;
+    private String githubId;
     private List<TechStack> techStack;
     private List<TechStack> interests;
     private String content;

--- a/src/main/java/com/devsong/server/user/entity/User.java
+++ b/src/main/java/com/devsong/server/user/entity/User.java
@@ -45,6 +45,12 @@ public class User {
     @CollectionTable
     private List<TechStack> techStack; //기술스택
 
+    //백준 아이디 수정
+    public void updateBojId(String bojId) { this.bojId = bojId; }
+
+    //깃허브 아이디 수정
+    public void updateGithubId(String githubId) { this.githubId = githubId; }
+
     //기술스택 수정
     public void updateTechStack(List<TechStack> techStack) {
         this.techStack = techStack;

--- a/src/main/java/com/devsong/server/user/service/ResumeService.java
+++ b/src/main/java/com/devsong/server/user/service/ResumeService.java
@@ -63,6 +63,10 @@ public class ResumeService {
         Resume resume = resumeRepository.findByUserId(userId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Resume not found"));
 
+        resume.getUser().updateBojId(dto.getBojId());
+
+        resume.getUser().updateGithubId(dto.getGithubId());
+
         resume.update(
                 dto.getInterests(),
                 dto.getContent(),


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
closed #71 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->


<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
<img width="431" height="358" alt="image" src="https://github.com/user-attachments/assets/b4d91474-0407-4485-9c16-740c557c6f0d" />

이력서에서 백준 아이디, 깃허브 아이디도 수정 가능하도록 추가

<img width="394" height="371" alt="image" src="https://github.com/user-attachments/assets/57b79ab9-c5de-46df-80fd-06530bf74bc2" />

수정 전

<img width="490" height="430" alt="image" src="https://github.com/user-attachments/assets/e507fa63-62ad-4c9a-90e6-ea4bd4794e7a" />

수정 후


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!— 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) —>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 이력서 업데이트 시 BOJ ID와 GitHub ID를 함께 수정할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->