### PR TITLE
[Feat] 회원가입 시 이메일 인증 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ dependencies {
 
 	//swagger 관련 의존성
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
+	//email 관련 의존성
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/devsong/server/jwt/SecurityConfig.java
+++ b/src/main/java/com/devsong/server/jwt/SecurityConfig.java
@@ -24,7 +24,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
                         //회원가입, 로그인 api 요청, swagger api 문서는 토큰 없이 가능하도록 허용
-                        .requestMatchers("/user/signup", "/user/login", "/user/check-email", "/swagger-ui/index.html",
+                        .requestMatchers("/user/signup", "/user/login", "/user/check-email", "user/send-email", "user/verify-code", "/swagger-ui/index.html",
                                 "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/devsong/server/security/SecurityConfig.java
+++ b/src/main/java/com/devsong/server/security/SecurityConfig.java
@@ -24,7 +24,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
                         //회원가입, 로그인 api 요청, swagger api 문서는 토큰 없이 가능하도록 허용
-                        .requestMatchers("/user/signup", "/user/login", "/user/check-email", "user/send-email", "user/verify-code", "/swagger-ui/index.html",
+                        .requestMatchers("/user/signup", "/user/login", "/user/check-email", "/user/send-email", "/user/verify-code", "/swagger-ui/index.html",
                                 "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/devsong/server/user/controller/UserController.java
+++ b/src/main/java/com/devsong/server/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.devsong.server.user.controller;
 
 import com.devsong.server.user.dto.*;
+import com.devsong.server.user.service.EmailService;
 import com.devsong.server.user.service.UserService;
 import com.devsong.server.user.service.ResumeService;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +19,8 @@ import io.swagger.v3.oas.annotations.Operation;
 public class UserController {
 
     private final UserService userService;
-    private final ResumeService resumeService;//DI
+    private final ResumeService resumeService;
+    private final EmailService emailService; //DI
 
     @Operation(summary = "회원가입")
     @PostMapping("/signup") //회원가입
@@ -36,6 +38,18 @@ public class UserController {
     @PostMapping("/check-email") //이메일 중복확인
     public EmailResponseDto checkEmail(@RequestBody EmailRequestDto emailRequestDto) {
         return userService.checkEmail(emailRequestDto);
+    }
+
+    @Operation(summary = "이메일로 인증번호 전송")
+    @PostMapping("/send-email")
+    public ResponseEntity<String> sendEmail(@RequestBody EmailRequestDto emailRequestDto) {
+        return ResponseEntity.ok(emailService.sendEmail(emailRequestDto));
+    }
+
+    @Operation(summary = "인증번호 일치 확인")
+    @PostMapping("/verify-code")
+    public EmailResponseDto verifyEmail(@RequestBody EmailVerifyRequestDto emailVerifyRequestDto) {
+        return emailService.verifyEmail(emailVerifyRequestDto);
     }
 
     @Operation(summary = "기술스택 등록")

--- a/src/main/java/com/devsong/server/user/dto/EmailVerifyRequestDto.java
+++ b/src/main/java/com/devsong/server/user/dto/EmailVerifyRequestDto.java
@@ -1,0 +1,9 @@
+package com.devsong.server.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class EmailVerifyRequestDto {
+    private String email;
+    private String code;
+}

--- a/src/main/java/com/devsong/server/user/entity/EmailVerification.java
+++ b/src/main/java/com/devsong/server/user/entity/EmailVerification.java
@@ -25,6 +25,7 @@ public class EmailVerification {
     public void updateCode(String code, int durationMinutes) {
         this.code = code;
         this.expirationTime = LocalDateTime.now().plusMinutes(durationMinutes);
+        this.attemptCount = 0; // 재발송 시 시도 횟수 초기화
     }
 
     // 만료 여부 확인

--- a/src/main/java/com/devsong/server/user/entity/EmailVerification.java
+++ b/src/main/java/com/devsong/server/user/entity/EmailVerification.java
@@ -1,0 +1,32 @@
+package com.devsong.server.user.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmailVerification {
+
+    @Id
+    private String email; // 이메일을 PK로 사용
+    private String code;
+    private LocalDateTime expirationTime; // 만료 시간
+
+    // 인증번호 업데이트를 위한 편의 메서드
+    public void updateCode(String code, int durationMinutes) {
+        this.code = code;
+        this.expirationTime = LocalDateTime.now().plusMinutes(durationMinutes);
+    }
+
+    // 만료 여부 확인
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(this.expirationTime);
+    }
+}

--- a/src/main/java/com/devsong/server/user/entity/EmailVerification.java
+++ b/src/main/java/com/devsong/server/user/entity/EmailVerification.java
@@ -18,6 +18,8 @@ public class EmailVerification {
     private String email; // 이메일을 PK로 사용
     private String code;
     private LocalDateTime expirationTime; // 만료 시간
+    private int attemptCount = 0; // 인증 시도 횟수
+    private static final int MAX_ATTEMPTS = 5; // 5번으로 제한
 
     // 인증번호 업데이트를 위한 편의 메서드
     public void updateCode(String code, int durationMinutes) {
@@ -28,5 +30,11 @@ public class EmailVerification {
     // 만료 여부 확인
     public boolean isExpired() {
         return LocalDateTime.now().isAfter(this.expirationTime);
+    }
+
+    // 인증 시도 횟수 제한
+    public boolean incrementAttemptAndCheckLimit() {
+        this.attemptCount++;
+        return this.attemptCount >= MAX_ATTEMPTS;
     }
 }

--- a/src/main/java/com/devsong/server/user/repository/EmailVerificationRepository.java
+++ b/src/main/java/com/devsong/server/user/repository/EmailVerificationRepository.java
@@ -1,0 +1,7 @@
+package com.devsong.server.user.repository;
+
+import com.devsong.server.user.entity.EmailVerification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmailVerificationRepository extends JpaRepository<EmailVerification, String> {
+}

--- a/src/main/java/com/devsong/server/user/repository/UserRepository.java
+++ b/src/main/java/com/devsong/server/user/repository/UserRepository.java
@@ -8,4 +8,5 @@ import org.springframework.stereotype.Repository;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     User findByEmail(String email);
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/devsong/server/user/service/EmailService.java
+++ b/src/main/java/com/devsong/server/user/service/EmailService.java
@@ -14,6 +14,7 @@ import java.security.SecureRandom;
 import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +24,7 @@ public class EmailService {
     private final EmailVerificationRepository verificationRepository; // 추가
     private final JavaMailSender mailSender;
 
+    @Transactional
     public String sendEmail(EmailRequestDto emailRequestDto) {
         String email = emailRequestDto.getEmail();
 
@@ -36,21 +38,23 @@ public class EmailService {
 
         // 기존에 발송한 이메일 정보가 있다면 업데이트, 없다면 새로 생성
         EmailVerification verification = verificationRepository.findById(email)
-                .orElse(new EmailVerification(email, verificationCode, LocalDateTime.now().plusMinutes(5)));
+                .orElse(new EmailVerification(email, verificationCode, LocalDateTime.now().plusMinutes(5), 0));
 
         verification.updateCode(verificationCode, 5); // 5분 유효
         verificationRepository.save(verification);
+        verificationRepository.flush();
 
         // 3. 이메일 발송
         try {
             sendMail(email, verificationCode);
-            return "Sended code";
+            return "Sent code";
         } catch (MessagingException e) {
-            return "Sending Fail";
+            throw new RuntimeException("Failed to send email", e);
         }
     }
 
     // 인증번호 검증 로직 완성
+    @Transactional
     public EmailResponseDto verifyEmail(EmailVerifyRequestDto emailVerifyRequestDto) {
         String email = emailVerifyRequestDto.getEmail();
         String inputCode = emailVerifyRequestDto.getCode();
@@ -71,8 +75,11 @@ public class EmailService {
             return new EmailResponseDto(false);
         }
 
-        if (!verification.getCode().equals(inputCode)) {
-            // 번호 불일치
+        if (!verification.getCode().equals(inputCode)) { // 인증번호 불일치할 경우
+            //인증 시도 횟수 확인
+            if (verification.incrementAttemptAndCheckLimit()) verificationRepository.delete(verification);
+            else verificationRepository.save(verification);
+
             return new EmailResponseDto(false);
         }
 

--- a/src/main/java/com/devsong/server/user/service/EmailService.java
+++ b/src/main/java/com/devsong/server/user/service/EmailService.java
@@ -1,0 +1,105 @@
+package com.devsong.server.user.service;
+
+import com.devsong.server.user.dto.EmailRequestDto;
+import com.devsong.server.user.dto.EmailResponseDto;
+import com.devsong.server.user.dto.EmailVerifyRequestDto;
+import com.devsong.server.user.entity.EmailVerification;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import com.devsong.server.user.repository.*;
+
+import java.time.LocalDateTime;
+import java.util.Random;
+import org.springframework.stereotype.Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final UserRepository userRepository;
+    private final EmailVerificationRepository verificationRepository; // 추가
+    private final JavaMailSender mailSender;
+
+    public String sendEmail(EmailRequestDto emailRequestDto) {
+        String email = emailRequestDto.getEmail();
+
+        // 1. 이메일 중복 체크
+        if (userRepository.existsByEmail(email)) {
+            return "This Email is already used";
+        }
+
+        // 2. 인증번호 생성 및 DB 저장
+        String verificationCode = generateCode();
+
+        // 기존에 발송한 이메일 정보가 있다면 업데이트, 없다면 새로 생성
+        EmailVerification verification = verificationRepository.findById(email)
+                .orElse(new EmailVerification(email, verificationCode, LocalDateTime.now().plusMinutes(5)));
+
+        verification.updateCode(verificationCode, 5); // 5분 유효
+        verificationRepository.save(verification);
+
+        // 3. 이메일 발송
+        try {
+            sendMail(email, verificationCode);
+            return "Sended code";
+        } catch (MessagingException e) {
+            return "Sending Fail";
+        }
+    }
+
+    // 인증번호 검증 로직 완성
+    public EmailResponseDto verifyEmail(EmailVerifyRequestDto emailVerifyRequestDto) {
+        String email = emailVerifyRequestDto.getEmail();
+        String inputCode = emailVerifyRequestDto.getCode();
+
+        // 1. 해당 이메일로 발급된 인증번호가 있는지 조회
+        EmailVerification verification = verificationRepository.findById(email)
+                .orElse(null);
+
+        // 2. 일치 여부 확인
+        if (verification == null) {
+            // 발급된 적 없는 이메일
+            return new EmailResponseDto(false);
+        }
+
+        if (verification.isExpired()) {
+            // 시간 만료
+            verificationRepository.delete(verification); // 만료된 데이터 삭제
+            return new EmailResponseDto(false);
+        }
+
+        if (!verification.getCode().equals(inputCode)) {
+            // 번호 불일치
+            return new EmailResponseDto(false);
+        }
+
+        // 3. 인증 성공 시 데이터 삭제 (또는 인증 완료 플래그 처리)
+        verificationRepository.delete(verification);
+
+        return new EmailResponseDto(true);
+    }
+
+    private String generateCode() {
+        Random random = new Random();
+        return String.format("%06d", random.nextInt(1000000));
+    }
+
+    private void sendMail(String email, String code) throws MessagingException {
+        MimeMessage message = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+        helper.setTo(email);
+        helper.setSubject("[DevSong] 회원가입 인증번호 안내");
+
+        String content = "<h3>안녕하세요, DevSong입니다.</h3>" +
+                "<p>회원가입을 위해 아래 인증번호를 입력해 주세요.</p>" +
+                "<h2 style='color: blue;'>" + code + "</h2>" +
+                "<p>인증번호는 5분간 유효합니다.</p>";
+
+        helper.setText(content, true);
+        mailSender.send(message);
+    }
+}

--- a/src/main/java/com/devsong/server/user/service/EmailService.java
+++ b/src/main/java/com/devsong/server/user/service/EmailService.java
@@ -10,7 +10,7 @@ import org.springframework.mail.javamail.MimeMessageHelper;
 import com.devsong.server.user.repository.*;
 
 import java.time.LocalDateTime;
-import java.util.Random;
+import java.security.SecureRandom;
 import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -83,7 +83,7 @@ public class EmailService {
     }
 
     private String generateCode() {
-        Random random = new Random();
+        SecureRandom random = new SecureRandom();
         return String.format("%06d", random.nextInt(1000000));
     }
 


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
closed #86 


<br><br>
## 📄 Work Description
- 이메일로 인증코드 발송 api
- 인증코드 확인 api 


<br><br>
## 📷 Screenshot
<img width="606" height="454" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/011336a4-8561-4829-a417-2ea5608b2d1f" />
<img width="1052" height="491" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/7dd537c9-a847-4602-97f2-cd3e0e208f79" />



<br><br>
## 💬 To Reviewers
- 인증번호를 일시 저장하기 위해 보통 redis를 사용하나 일시적으로 mysql db에 저장하는 방법으로 구현했습니다
- api 명세서 업데이트 완료
- **applicaton.properties 추가 사항 있습니다**

<br><br>
## 🔗 Reference
<!— 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) —>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 이메일 기반 인증 추가: 사용자가 6자리 인증 코드를 이메일로 요청하고 검증할 수 있습니다.
  * 인증 코드는 5분간 유효하며 일회용입니다.
  * 인증 시도 횟수 제한(최대 5회)으로 무단 시도 방지.
  * 가입된 이메일 중복 체크로 이미 등록된 계정에 대한 인증 요청 차단.
  * 인증 요청 및 검증을 위한 공개 API 엔드포인트가 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->