### PR TITLE
[Feat] 마이페이지 프로필 수정 탭 조회 및 수정 기능 구현

### DIFF
--- a/src/main/java/com/devsong/server/user/controller/UserController.java
+++ b/src/main/java/com/devsong/server/user/controller/UserController.java
@@ -124,4 +124,21 @@ public class UserController {
         s3Service.delete(userId);
         return ResponseEntity.ok("Deleted profile image");
     }
+
+    @Operation(summary = "마이페이지 프로필 조회")
+    @GetMapping("/me")
+    public ResponseEntity<MyPageProfileResponseDto> getMyProfile(
+            @AuthenticationPrincipal Long userId) {
+
+        return ResponseEntity.ok(userService.getMyProfile(userId));
+    }
+
+    @Operation(summary = "내 프로필 수정")
+    @PostMapping("/me")
+    public ResponseEntity<MyPageProfileResponseDto> updateMyProfile(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody MyPageUpdateRequestDto dto) {
+
+        return ResponseEntity.ok(userService.updateMyProfile(userId, dto));
+    }
 }

--- a/src/main/java/com/devsong/server/user/dto/MyPageProfileResponseDto.java
+++ b/src/main/java/com/devsong/server/user/dto/MyPageProfileResponseDto.java
@@ -1,0 +1,15 @@
+package com.devsong.server.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MyPageProfileResponseDto {
+
+    private String profileImageUrl;
+    private String username;
+    private Long studentId;
+    private String major;
+    private String email;
+}

--- a/src/main/java/com/devsong/server/user/dto/MyPageUpdateRequestDto.java
+++ b/src/main/java/com/devsong/server/user/dto/MyPageUpdateRequestDto.java
@@ -1,0 +1,12 @@
+package com.devsong.server.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class MyPageUpdateRequestDto {
+
+    private String username;
+    private Long studentId;
+    private String major;
+    private String email;
+}

--- a/src/main/java/com/devsong/server/user/dto/MyPostDto.java
+++ b/src/main/java/com/devsong/server/user/dto/MyPostDto.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 @Builder
 @AllArgsConstructor
 public class MyPostDto {
-    private final Long postId;
+    private final Long id;
     private final String title;      // 제목
     private final String preview;    // 미리보기
     private final Category category; // 카테고리
@@ -20,6 +20,6 @@ public class MyPostDto {
     private final LocalDateTime createdAt;  // 작성 시간
 
     private final boolean closed;   // 모집 마감 여부
-    private final Long like;        // 좋아요 수
+    private final Long likeCount;        // 좋아요 수
     private final Long comment;     // 댓글 수
 }

--- a/src/main/java/com/devsong/server/user/entity/User.java
+++ b/src/main/java/com/devsong/server/user/entity/User.java
@@ -92,4 +92,12 @@ public class User {
         this.profileImageUrl = null;
         this.profileS3Key = null;
     }
+
+    // 마이페이지 프로필 수정
+    public void updateMyPageInfo(String username, Long studentId, String major, String email) {
+        if (username != null) this.username = username;
+        if (studentId != null) this.studentId = studentId;
+        if (major != null) this.major = major;
+        if (email != null) this.email = email;
+    }
 }

--- a/src/main/java/com/devsong/server/user/service/UserService.java
+++ b/src/main/java/com/devsong/server/user/service/UserService.java
@@ -143,14 +143,14 @@ public class UserService {
     public List<MyPostDto> getMyPosts(Long userId) {
         return postRepository.findByUserIdOrderByIdDesc(userId).stream()
                 .map(post -> MyPostDto.builder()
-                        .postId(post.getId())
+                        .id(post.getId())
                         .title(post.getTitle())
                         .preview(preview(post.getContent(), 35))
                         .category(post.getCategory())
                         .username(post.getUser().getUsername())
                         .createdAt(post.getCreatedAt())
                         .closed(post.isClosed())
-                        .like(postLikeRepository.countByPostId(post.getId()))
+                        .likeCount(postLikeRepository.countByPostId(post.getId()))
                         .comment(commentRepository.countByPostId(post.getId()))
                         .build())
                 .collect(Collectors.toList());
@@ -162,14 +162,14 @@ public class UserService {
                 .map(comment -> {
                     var post = comment.getPost();
                     return MyPostDto.builder()
-                            .postId(post.getId())
+                            .id(post.getId())
                             .title(post.getTitle())
                             .preview(preview(post.getContent(), 35))
                             .category(post.getCategory())
                             .username(post.getUser().getUsername())
                             .createdAt(post.getCreatedAt())
                             .closed(post.isClosed())
-                            .like(postLikeRepository.countByPostId(post.getId()))
+                            .likeCount(postLikeRepository.countByPostId(post.getId()))
                             .comment(commentRepository.countByPostId(post.getId()))
                             .build();
                 })
@@ -181,14 +181,14 @@ public class UserService {
         return postLikeRepository.findByUserId(userId).stream()
                 .map(PostLike::getPost)
                 .map(post -> MyPostDto.builder()
-                        .postId(post.getId())
+                        .id(post.getId())
                         .title(post.getTitle())
                         .preview(preview(post.getContent(), 35))
                         .category(post.getCategory())
                         .username(post.getUser().getUsername())
                         .createdAt(post.getCreatedAt())
                         .closed(post.isClosed())
-                        .like(postLikeRepository.countByPostId(post.getId()))
+                        .likeCount(postLikeRepository.countByPostId(post.getId()))
                         .comment(commentRepository.countByPostId(post.getId()))
                         .build())
                 .collect(Collectors.toList());
@@ -199,16 +199,57 @@ public class UserService {
         return postApplyRepository.findByUserId(userId).stream()
                 .map(PostApply::getPost)
                 .map(post -> MyPostDto.builder()
-                        .postId(post.getId())
+                        .id(post.getId())
                         .title(post.getTitle())
                         .preview(preview(post.getContent(), 35))
                         .category(post.getCategory())
                         .username(post.getUser().getUsername())
                         .createdAt(post.getCreatedAt())
                         .closed(post.isClosed())
-                        .like(postLikeRepository.countByPostId(post.getId()))
+                        .likeCount(postLikeRepository.countByPostId(post.getId()))
                         .comment(commentRepository.countByPostId(post.getId()))
                         .build())
                 .collect(Collectors.toList());
+    }
+
+    // 마이페이지 프로필
+    public MyPageProfileResponseDto getMyProfile(Long userId) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        return MyPageProfileResponseDto.builder()
+                .profileImageUrl(user.getProfileImageUrl())
+                .username(user.getUsername())
+                .studentId(user.getStudentId())
+                .major(user.getMajor())
+                .email(user.getEmail())
+                .build();
+    }
+
+    // 마이페이지 프로필 수정
+    @Transactional
+    public MyPageProfileResponseDto updateMyProfile(
+            Long userId,
+            MyPageUpdateRequestDto dto
+    ) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        user.updateMyPageInfo(
+                dto.getUsername(),
+                dto.getStudentId(),
+                dto.getMajor(),
+                dto.getEmail()
+        );
+
+        return MyPageProfileResponseDto.builder()
+                .profileImageUrl(user.getProfileImageUrl())
+                .username(user.getUsername())
+                .studentId(user.getStudentId())
+                .major(user.getMajor())
+                .email(user.getEmail())
+                .build();
     }
 }


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#99 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->
- 마이페이지 api 연동하다가 마이페이지의 프로필 수정 탭 조회 및 수정 기능이 없어서 새롭게 구현했습니다!
- GET /api/post와 key값도 모두 통일했어요! (like -> likeCount, postId -> id)

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!— 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) —>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 개인 프로필 조회 기능 추가 - 사용자 정보(프로필 이미지, 사용자명, 학번, 전공, 이메일) 확인 가능
  * 개인 프로필 수정 기능 추가 - 사용자 정보 업데이트 가능

* **Style**
  * 게시물 목록에서 필드명 개선 - postId → id, like → likeCount로 변경

<!-- end of auto-generated comment: release notes by coderabbit.ai -->